### PR TITLE
Update trackers to use manifest and handle tar archives

### DIFF
--- a/nipoppy/trackers/bagel_schema.json
+++ b/nipoppy/trackers/bagel_schema.json
@@ -1,0 +1,94 @@
+{
+    "GLOBAL_COLUMNS": {
+        "participant_id": {
+            "Description": "Participant identifier within a given dataset.", 
+            "dtype": "str",
+            "IsRequired": true,
+            "IsPrefixedColumn": false
+        },
+        "bids_id": {
+            "Description": "BIDS dataset identifier for a participant, if available/different from the participant_id.", 
+            "dtype": "str",
+            "IsRequired": false,
+            "IsPrefixedColumn": false
+        },
+        "session": {
+            "Description": "Participant session ID.", 
+            "dtype": "str",
+            "IsRequired": true,
+            "IsPrefixedColumn": false
+        },
+        "has_mri_data": {
+            "Description": "Whether or not participant had MRI data acquired in a given session.",
+            "dtype": "bool",
+            "IsRequired": false,
+            "Range": [true, false],
+            "IsPrefixedColumn": false
+        },
+        "HAS_DATATYPE__": {
+            "Description": "Whether or not participant session has specified raw BIDS datatype. Column suffix should correspond to a specific BIDS subdirectory. e.g., 'HAS_DATATYPE__anat'",
+            "dtype": "bool",
+            "IsRequired": false,
+            "Range": [true, false],
+            "IsPrefixedColumn": true
+        },
+        "HAS_IMAGE__": {
+            "Description": "Whether or not participant session has specified imaging file. Column suffix should correspond to a BIDS file suffix. e.g. 'HAS_IMAGE__T1w'",
+            "dtype": "bool",
+            "IsRequired": false,
+            "Range": [true, false],
+            "IsPrefixedColumn": true
+        },
+        "pipeline_name": {
+            "Description": "Name of a pipeline that was run for the participant, if applicable. Example value: 'freesurfer'",
+            "dtype": "str",
+            "IsRequired": true,
+            "MissingValue": "UNAVAILABLE",
+            "IsPrefixedColumn": false
+        },     
+        "pipeline_version": {
+            "description": "Version of pipeline that was run. Must have a value if the value for 'pipeline_name' is not 'UNAVAILABLE'. Example value: '7.3.0'",
+            "dtype": "str",
+            "IsRequired": true,
+            "MissingValue": "UNAVAILABLE",
+            "IsPrefixedColumn": false
+        },
+        "pipeline_starttime": {
+            "Description": "Date/time that pipeline run was started. In format of 'YYYY-MM-DD HH:MM:SS'.",
+            "dtype": "str",
+            "IsRequired": true,
+            "MissingValue": "UNAVAILABLE",
+            "IsPrefixedColumn": false
+        },
+        "pipeline_endtime": {
+            "Description": "Date/time that pipeline run ended. In format of 'YYYY-MM-DD HH:MM:SS'.",
+            "dtype": "str",
+            "IsRequired": false,
+            "MissingValue": "UNAVAILABLE",
+            "IsPrefixedColumn": false
+        }
+    },
+    "PIPELINE_STATUS_COLUMNS": {
+        "pipeline_complete": {
+            "Description": "Status of pipeline run. 'SUCCESS': All stages of pipeline (as configured by user) finished successfully (all expected pipeline output files are present). 'FAIL': At least one stage of the pipeline failed. 'INCOMPLETE': Pipeline has not yet been run for the participant or at least one stage is unfinished/still running. 'UNAVAILABLE': Relevant data modality for pipeline not available for participant.",
+            "dtype": "str",
+            "IsRequired": true,
+            "Range": ["SUCCESS", "FAIL", "INCOMPLETE", "UNAVAILABLE"],
+            "IsPrefixedColumn": false
+        },
+        "PHASE__": {
+            "Description": "Completion status of tracker-specified phase/subworkflow of a pipeline. This prefix must be followed by a second that is a composite of {pipeline_name}-{pipeline_version} to be grouped to the relevant pipeline. e.g., 'PHASE__fmriprep-20.2.7__func'. Each phase may correspond to a specific output subdirectory, and may be associated with multiple related output files. If phase and stage columns are both present, each phase is expected to correspond to >= 1 stage. 'SUCCESS': All output files corresponding to phase are present. 'FAIL': At least one output file of phase is missing. This status may be used to indicate that the phase crashed. 'INCOMPLETE': Output files for phase are not present. This status may be used to indicate that the phase was not configured for the run (e.g., if it corresponds to a specific derivative type). 'UNAVAILABLE': Relevant data modality for pipeline not available for participant. '' (no value):  Specified phase not part of pipeline described by current row/record.",
+            "dtype": "str",
+            "IsRequired": false,
+            "Range": ["SUCCESS", "FAIL", "INCOMPLETE", "UNAVAILABLE", ""],
+            "IsPrefixedColumn": true
+        },
+        "STAGE__": {
+            "Description": "Completion status of tracker-specified stage of a pipeline. This prefix must be followed by a second that is a composite of {pipeline_name}-{pipeline_version} to be grouped to the relevant pipeline. e.g., 'STAGE__fmriprep-20.2.7__space-MNI152Lin_res-1'. Each stage may correspond to a single output file or a few linked outputs expected to always coexist. If phase and stage columns are both present, each phase is expected to correspond to >= 1 stage. 'SUCCESS': All output files corresponding to stage are present. 'FAIL': At least one output file of stage is missing. This status may be used to indicate that the stage crashed. 'INCOMPLETE': Output files for phase are not present. This status may be used to indicate that this stage was not configured for the run. 'UNAVAILABLE': Relevant data modality for pipeline not available for participant. '' (no value): Specified stage not part of pipeline described by current row/record.",
+            "dtype": "str",
+            "IsRequired": false,
+            "Range": ["SUCCESS", "FAIL", "INCOMPLETE", "UNAVAILABLE", ""],
+            "IsPrefixedColumn": true
+        }
+    }
+}

--- a/nipoppy/trackers/run_tracker.py
+++ b/nipoppy/trackers/run_tracker.py
@@ -243,12 +243,12 @@ def run(global_configs, dash_schema_file, pipelines, session_id="ALL", run_id="1
             _df = _df.reset_index(drop=True)
 
             # add old rows from other pipelines/sessions and sort for consistent order
-            df_bagel: pd.DataFrame = pd.concat([df_bagel_old, _df], axis='index')
+            df_bagel: pd.DataFrame = pd.concat([df_bagel_old, _df], axis='index', ignore_index=True)
             df_bagel = df_bagel.sort_values(["pipeline_name", "pipeline_version", COL_BIDS_ID_MANIFEST, COL_SESSION_MANIFEST], ignore_index=True)
 
             # don't write a new file if no changes
             try:
-                if len(df_bagel.compare(df_bagel_old_full)) == 0:
+                if (df_bagel.shape == df_bagel_old_full.shape) and (set(df_bagel.columns) == set(df_bagel_old_full.columns)) and (len(df_bagel.compare(df_bagel_old_full)) == 0):
                     logger.info(f'No change in bagel file for pipeline {pipeline}, session {session}')
                     continue
             except Exception as exception:

--- a/nipoppy/trackers/run_tracker.py
+++ b/nipoppy/trackers/run_tracker.py
@@ -39,6 +39,7 @@ PIPELINE_REQUIRED_DATATYPES = {
     "mriqc": ["anat"],
     "tractoflow": ["anat", "dwi"],
 }
+ALL_DATATYPES = sorted(["anat", "dwi", "func", "fmap"])
 BIDS_PIPES = ["mriqc","fmriprep"]
 NO_TRACKER_PIPES = ["maget_brain"]
 
@@ -100,6 +101,8 @@ def run(global_configs, dash_schema_file, pipelines, session_id="ALL", run_id="1
         # for prefixed columns we need to generate the column name
         dash_col_list = list(key for key, value in schema["GLOBAL_COLUMNS"].items() if not value["IsPrefixedColumn"])
         # status_check_dict will typically only have minimal pipeline_complete key
+        for datatype in ALL_DATATYPES:
+            dash_col_list.append(f"HAS_DATATYPE__{datatype}")
         dash_col_list = dash_col_list + list(status_check_dict.keys())
 
         for session in sessions:
@@ -194,6 +197,10 @@ def run(global_configs, dash_schema_file, pipelines, session_id="ALL", run_id="1
                 ]
                 subject_ses_tar_status = any([path.exists() for path in subject_ses_tar_paths])
                 logger.debug(f"subject_ses_dir: {subject_ses_dir}, dir_status: {subject_ses_dir_status}, subject_ses_tar_status: {subject_ses_tar_status}")
+
+                # populate HAS_DATATYPE__ columns
+                for datatype in ALL_DATATYPES:
+                    _df.loc[bids_id, f"HAS_DATATYPE__{datatype}"] = datatype in datatypes
                 
                 if subject_ses_tar_status:
                     logger.debug(f"subject_ses_dir: {subject_ses_dir} is a tar file")

--- a/nipoppy/trackers/run_tracker.py
+++ b/nipoppy/trackers/run_tracker.py
@@ -11,19 +11,16 @@ import nipoppy.workflow.logger as my_logger
 from nipoppy.trackers.tracker import Tracker, get_start_time, get_end_time, SUCCESS, UNAVAILABLE, INCOMPLETE, TRUE
 from nipoppy.trackers import bids_tracker, fs_tracker, fmriprep_tracker, mriqc_tracker, tractoflow_tracker
 from nipoppy.workflow.utils import (
-    BIDS_SUBJECT_PREFIX,
     BIDS_SESSION_PREFIX,
     COL_DATATYPE_MANIFEST,
     COL_SUBJECT_MANIFEST,
     COL_BIDS_ID_MANIFEST,
     COL_SESSION_MANIFEST,
-    COL_CONV_STATUS, 
     DNAME_BACKUPS_BAGEL,
     FNAME_BAGEL,
     FNAME_MANIFEST,
     load_manifest,
     save_backup,
-    session_id_to_bids_session,
 )
 
 # Globals
@@ -74,7 +71,6 @@ def run(global_configs, dash_schema_file, pipelines, session_id="ALL", run_id="1
         pipe_tracker = Tracker(global_configs, dash_schema_file, pipeline) 
         
         # TODO revise tracker class
-        # DATASET_ROOT, session_ids, version = pipe_tracker.get_global_configs()
         if pipeline == "heudiconv":
             version = global_configs["BIDS"][pipeline]["VERSION"]
         else:
@@ -227,7 +223,7 @@ def run(global_configs, dash_schema_file, pipelines, session_id="ALL", run_id="1
 
             # add old rows from other pipelines/sessions and sort for consistent order
             df_bagel: pd.DataFrame = pd.concat([df_bagel_old, _df], axis='index')
-            df_bagel = df_bagel.sort_values(["pipeline_name", "pipeline_version", COL_BIDS_ID_MANIFEST], ignore_index=True)
+            df_bagel = df_bagel.sort_values(["pipeline_name", "pipeline_version", COL_BIDS_ID_MANIFEST, COL_SESSION_MANIFEST], ignore_index=True)
 
             # don't write a new file if no changes
             try:

--- a/nipoppy/trackers/run_tracker.py
+++ b/nipoppy/trackers/run_tracker.py
@@ -190,14 +190,6 @@ def run(global_configs, dash_schema_file, pipelines, session_id="ALL", run_id="1
                 else:
                     logger.error(f"unknown pipeline: {pipeline}")
                 
-                subject_ses_dir_status = Path(subject_ses_dir).is_dir()
-                subject_ses_tar_paths = [
-                    Path(subject_ses_dir).with_suffix('.tar'),
-                    Path(subject_ses_dir).with_suffix('.tar.gz'),
-                ]
-                subject_ses_tar_status = any([path.exists() for path in subject_ses_tar_paths])
-                logger.debug(f"subject_ses_dir: {subject_ses_dir}, dir_status: {subject_ses_dir_status}, subject_ses_tar_status: {subject_ses_tar_status}")
-
                 # populate HAS_DATATYPE__ columns
                 # and check if all required datatypes are available
                 required_datatypes = PIPELINE_REQUIRED_DATATYPES[pipeline]
@@ -208,12 +200,23 @@ def run(global_configs, dash_schema_file, pipelines, session_id="ALL", run_id="1
                         has_required_datatypes = False
                 
                 if has_required_datatypes:
+
+                    subject_ses_dir_status = Path(subject_ses_dir).is_dir()
+                    subject_ses_tar_paths = [
+                        Path(subject_ses_dir).with_suffix('.tar'),
+                        Path(subject_ses_dir).with_suffix('.tar.gz'),
+                    ]
+                    subject_ses_tar_status = any([path.exists() for path in subject_ses_tar_paths])
+                    logger.debug(f"subject_ses_dir: {subject_ses_dir}, dir_status: {subject_ses_dir_status}, subject_ses_tar_status: {subject_ses_tar_status}")
+
                     if subject_ses_tar_status:
                         logger.debug(f"subject_ses_dir: {subject_ses_dir} is a tar file")
                         for name in status_check_dict.keys():
                             if name == 'pipeline_complete':
                                 _df.loc[bids_id,name] = SUCCESS
                             else:
+                                # here, UNAVAILABLE refers to the functionality not being implemented yet for phases/stages
+                                # unrelated to pipeline_complete being UNAVAILABLE, which is related to the datatypes column in the manifest
                                 _df.loc[bids_id,name] = UNAVAILABLE  # TODO check if files are available in the tar file
                             _df.loc[bids_id,"pipeline_starttime"] = UNAVAILABLE
                             _df.loc[bids_id,"pipeline_endtime"] = UNAVAILABLE

--- a/nipoppy/trackers/run_tracker.py
+++ b/nipoppy/trackers/run_tracker.py
@@ -251,7 +251,7 @@ def run(global_configs, dash_schema_file, pipelines, session_id="ALL", run_id="1
 
             # don't write a new file if no changes
             try:
-                if (df_bagel.shape == df_bagel_old_full.shape) and (set(df_bagel.columns) == set(df_bagel_old_full.columns)) and (len(df_bagel.compare(df_bagel_old_full)) == 0):
+                if (df_bagel_old is not None) and (df_bagel.shape == df_bagel_old_full.shape) and (set(df_bagel.columns) == set(df_bagel_old_full.columns)) and (len(df_bagel.compare(df_bagel_old_full)) == 0):
                     logger.info(f'No change in bagel file for pipeline {pipeline}, session {session}')
                     continue
             except Exception as exception:


### PR DESCRIPTION
Closes #180, closes #174, closes #97 (except for the `--check-for-update` flag)

With a minor bug fix that made the script write new bagel files even if they didn't change from the previous version.

Some notes:
- Added more logic to handle the fMRIPrep 20.2.7 results being in `output/fmriprep` instead of just `output`. So @nikhil153 depending on your setup for QPN/NIMHANS we might need to put things back into an `fmriprep` subdirectory
- I have a personal preference for using the version name without a preceding `v`, which is how I have coded the Boutiques thing to do for now. This PR makes the tracker compatible with the current Boutiques runner outputs. So this will break things with older runscripts unless we rename the version directories (e.g. `v20.2.7` -> `20.2.7`). @nikhil153 let me know what you think about that