### PR TITLE
Fix MRIQC (and fMRIPrep) runscript bugs 

### DIFF
--- a/nipoppy/workflow/proc_pipe/fmriprep/run_fmriprep.py
+++ b/nipoppy/workflow/proc_pipe/fmriprep/run_fmriprep.py
@@ -137,7 +137,7 @@ def run(participant_id: str,
     log_dir = f"{DATASET_ROOT}/scratch/logs/"
 
     if logger is None:
-        log_file = f"{log_dir}/fmriprep1.log"
+        log_file = f"{log_dir}/fmriprep.log"
         logger = my_logger.get_logger(log_file)
 
     logger.info("-"*75)

--- a/nipoppy/workflow/proc_pipe/fmriprep/run_fmriprep.py
+++ b/nipoppy/workflow/proc_pipe/fmriprep/run_fmriprep.py
@@ -16,6 +16,7 @@ CWD = os.path.dirname(os.path.abspath(fname))
 SINGULARITY_FS_DIR = "/fsdir/"
 SINGULARITY_TEMPLATEFLOW_DIR = "/templateflow"
 SINGULARITY_FS_LICENSE = "/fsdir/license.txt"
+DNAME_BIDS_DB = 'bids_db_fmriprep'
 os.environ['SINGULARITYENV_SUBJECTS_DIR'] = SINGULARITY_FS_DIR
 os.environ['SINGULARITYENV_FS_LICENSE'] = SINGULARITY_FS_LICENSE
 os.environ['SINGULARITYENV_TEMPLATEFLOW_HOME'] = SINGULARITY_TEMPLATEFLOW_DIR
@@ -38,8 +39,12 @@ def run_fmriprep(participant_id: str,
     fmriprep_home_dir = f"{fmriprep_out_dir}/fmriprep_home_{participant_id}/"
     Path(f"{fmriprep_home_dir}").mkdir(parents=True, exist_ok=True)
 
-    # BIDS DB created for fmriprep by run_nipoppy.py
-    bids_db_dir = f"/fmripre_proc/bids_db_fmriprep"
+    bids_db_dir = f"/fmripre_proc/{DNAME_BIDS_DB}"
+
+    bids_db_dir_outside_container = f"{proc_dir}/{DNAME_BIDS_DB}"
+    if not Path(bids_db_dir_outside_container).exists():
+        logger.warning(f"Creating the BIDS database directory because it does not exist: {bids_db_dir_outside_container}")
+        Path(bids_db_dir_outside_container).mkdir(parents=True, exist_ok=True)
 
     # Singularity CMD 
     SINGULARITY_CMD=f"singularity run \

--- a/nipoppy/workflow/proc_pipe/fmriprep/run_fmriprep.py
+++ b/nipoppy/workflow/proc_pipe/fmriprep/run_fmriprep.py
@@ -48,6 +48,8 @@ def run_fmriprep(participant_id: str,
     if not Path(bids_db_dir_outside_container).exists():
         logger.warning(f"Creating the BIDS database directory because it does not exist: {bids_db_dir_outside_container}")
         Path(bids_db_dir_outside_container).mkdir(parents=True, exist_ok=True)
+    else:
+        logger.info(f"Using existing BIDS database directory: {bids_db_dir_outside_container}")
 
     if regenerate_bids_db:
         for path in Path(bids_db_dir_outside_container).glob("*"):

--- a/nipoppy/workflow/proc_pipe/fmriprep/run_fmriprep.py
+++ b/nipoppy/workflow/proc_pipe/fmriprep/run_fmriprep.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import json
 import subprocess

--- a/nipoppy/workflow/proc_pipe/mriqc/run_mriqc.py
+++ b/nipoppy/workflow/proc_pipe/mriqc/run_mriqc.py
@@ -38,9 +38,9 @@ def run(participant_id, global_configs, session_id, output_dir, modalities, logg
     if not Path(bids_db_dir_outside_container).exists():
         logger.warning(f"Creating the BIDS database directory because it does not exist: {bids_db_dir_outside_container}")
         Path(bids_db_dir_outside_container).mkdir(parents=True, exist_ok=True)
+    else:
+        logger.info(f"Using existing BIDS database directory: {bids_db_dir_outside_container}")
        
-    logger.info(f"bids_db_dir: {bids_db_dir_outside_container}")
-
     if regenerate_bids_db:
         for path in Path(bids_db_dir_outside_container).glob("*"):
             if path.is_file():

--- a/nipoppy/workflow/proc_pipe/mriqc/run_mriqc.py
+++ b/nipoppy/workflow/proc_pipe/mriqc/run_mriqc.py
@@ -34,7 +34,7 @@ def run(participant_id, global_configs, session_id, output_dir, modalities, bids
     # if it is never provided then we should remove that argument and just always use the default
     if bids_db_dir is None:
         bids_db_dir = f"/mriqc_proc/{DEFAULT_DNAME_BIDS_DB}"
-        
+
         bids_db_dir_outside_container = f"{proc_dir}/{DEFAULT_DNAME_BIDS_DB}"
         if not Path(bids_db_dir_outside_container).exist():
             logger.warning(f"Creating the BIDS database directory because it does not exist: {bids_db_dir_outside_container}")
@@ -66,6 +66,7 @@ def run(participant_id, global_configs, session_id, output_dir, modalities, bids
         -B {mriqc_output_dir}:/out \
         -B {mriqc_work_dir}:/work \
         -B {TEMPLATEFLOW_DIR}:{SINGULARITY_TEMPLATEFLOW_DIR} \
+        --cleanenv \
         {SINGULARITY_CONTAINER} "
 
     # Compose mriqc command

--- a/nipoppy/workflow/proc_pipe/mriqc/run_mriqc.py
+++ b/nipoppy/workflow/proc_pipe/mriqc/run_mriqc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import subprocess
 import sys
 import argparse

--- a/nipoppy/workflow/proc_pipe/mriqc/run_mriqc.py
+++ b/nipoppy/workflow/proc_pipe/mriqc/run_mriqc.py
@@ -7,11 +7,11 @@ import nipoppy.workflow.logger as my_logger
 from pathlib import Path
 import os
 
-DEFAULT_DNAME_BIDS_DB = 'bids_db_mriqc'
+DNAME_BIDS_DB = 'bids_db_mriqc'
 SINGULARITY_TEMPLATEFLOW_DIR = "/templateflow"
 os.environ['SINGULARITYENV_TEMPLATEFLOW_HOME'] = SINGULARITY_TEMPLATEFLOW_DIR
 
-def run(participant_id, global_configs, session_id, output_dir, modalities, bids_db_dir=None, logger=None, regenerate_bids_db=False):
+def run(participant_id, global_configs, session_id, output_dir, modalities, logger=None, regenerate_bids_db=False):
     """ Runs mriqc command
     """
     DATASET_ROOT = global_configs["DATASET_ROOT"]
@@ -31,16 +31,13 @@ def run(participant_id, global_configs, session_id, output_dir, modalities, bids
         log_file = f"{log_dir}/mriqc.log"
         logger = my_logger.get_logger(log_file)
 
-    # TODO what do we do if the bids_db_dir is provided? Is it the name of the directory relative to proc?
-    # if it is never provided then we should remove that argument and just always use the default
-    if bids_db_dir is None:
-        # path inside the container
-        bids_db_dir = f"/mriqc_proc/{DEFAULT_DNAME_BIDS_DB}"
+    # path inside the container
+    bids_db_dir = f"/mriqc_proc/{DNAME_BIDS_DB}"
 
-        bids_db_dir_outside_container = f"{proc_dir}/{DEFAULT_DNAME_BIDS_DB}"
-        if not Path(bids_db_dir_outside_container).exists():
-            logger.warning(f"Creating the BIDS database directory because it does not exist: {bids_db_dir_outside_container}")
-            Path(bids_db_dir_outside_container).mkdir(parents=True, exist_ok=True)
+    bids_db_dir_outside_container = f"{proc_dir}/{DNAME_BIDS_DB}"
+    if not Path(bids_db_dir_outside_container).exists():
+        logger.warning(f"Creating the BIDS database directory because it does not exist: {bids_db_dir_outside_container}")
+        Path(bids_db_dir_outside_container).mkdir(parents=True, exist_ok=True)
        
     logger.info(f"bids_db_dir: {bids_db_dir_outside_container}")
 
@@ -123,7 +120,6 @@ if __name__ == '__main__':
     parser.add_argument('--session_id', type=str, required=True, help='session id for the participant')
     parser.add_argument('--output_dir', type=str, default=None, help='specify custom output dir (if None, output is saved at <DATASET_ROOT>/derivatives/mriqc)')
     parser.add_argument('--modalities', nargs="*", required=True, help='specify modalities (i.e. suffixes) to QC. Possible options: T1w, T2w, bold, dwi')
-    parser.add_argument('--bids_db_path', type=str, default=None, help='path pybids layout db')
     parser.add_argument('--regenerate_bids_db', action='store_true', help='regenerate PyBIDS database (default: use existing if available)')
 
     args = parser.parse_args()
@@ -133,7 +129,6 @@ if __name__ == '__main__':
     session_id = args.session_id
     output_dir = args.output_dir
     modalities = args.modalities
-    bids_db_path = args.bids_db_path
     regenerate_bids_db = args.regenerate_bids_db
 
     # Read global configs
@@ -144,4 +139,4 @@ if __name__ == '__main__':
     participant_id = args.participant_id
     session_id = args.session_id
 
-    run(participant_id, global_configs, session_id, output_dir, modalities, bids_db_path, regenerate_bids_db=regenerate_bids_db)
+    run(participant_id, global_configs, session_id, output_dir, modalities, regenerate_bids_db=regenerate_bids_db)


### PR DESCRIPTION
Closes #193.

- If the `bids_db_dir` does not exist, write warning in log and create it
  - There was a note saying that `run_nipoppy.py` created those directories, but since we don't require that users run `run_nipoppy.py`, we should handle (within the runscript) the case where the `bids_db_dir` does not exist
  - @nikhil153 `bids_db_dir` is not an argument in `run_fmriprep.run()`, but it is in `run_mriqc.run()`. It is unclear to me what users should provide if they provide a custom path, and it will break things if that path is not already accessible inside the container. So I suggest doing what we do in `run_fmriprep.run()` and just not have it as an argument that the user sets (i.e., always use `<DATASET_ROOT>/proc/<bids_db_mriqc>`)
- Add `--cleanenv` argument to the Singularity `run` call for MRIQC