### PR TITLE
[DOC] make install command more robust

### DIFF
--- a/nipoppy_cli/docs/source/installation.md
+++ b/nipoppy_cli/docs/source/installation.md
@@ -101,7 +101,7 @@ $ pip install -e .
 ````{note}
 You can also install the package with `dev` dependencies (e.g., for running tests and building documentation):
 ```{code-block} console
-$ pip install -e .[dev]
+$ pip install -e '.[dev]'
 ```
 ````
 


### PR DESCRIPTION
I cannot remember if this is a powershell or just another type of shell issue, but I know that fr some users you need to type:

`pip install -e '.[dev]'`