### PR TITLE
[FIX] Make sure Python >=3.9 is supported

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@ exclude =
 	venv,
 per-file-ignores =
     # - docstrings rules that should not be applied to tests
-	**/test_*: D100, D103, D104
+	**/test_*: D100, D101, D103, D104
     __init__.py:F401
     # allow "weird indentation"
 	tests/test_workflow_*.py: D100, D103, D104, E131, E127, E501

--- a/.github/workflows/run_tests_new.yml
+++ b/.github/workflows/run_tests_new.yml
@@ -18,6 +18,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12]
+
     # only trigger on upstream repo
     if: github.repository_owner == 'neurodatascience' && github.event.repository.name == 'nipoppy'
 
@@ -29,7 +33,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install package
       run: |

--- a/.github/workflows/run_tests_new.yml
+++ b/.github/workflows/run_tests_new.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     # only trigger on upstream repo
     if: github.repository_owner == 'neurodatascience' && github.event.repository.name == 'nipoppy'

--- a/nipoppy_cli/docs/source/conf.py
+++ b/nipoppy_cli/docs/source/conf.py
@@ -86,6 +86,9 @@ nitpick_ignore = [
     ("py:class", "argparse.HelpFormatter"),
     ("py:class", "argparse._SubParsersAction"),
     ("py:class", "argparse._ActionsContainer"),
+    ("py:class", "StrOrPathLike"),
+    ("py:class", "nipoppy.utils.StrOrPathLike"),
+    ("py:class", "typing_extensions.Self"),
 ]
 
 # -- Copybutton configuration -------------------------------------------------

--- a/nipoppy_cli/nipoppy/config/container.py
+++ b/nipoppy_cli/nipoppy/config/container.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 from nipoppy.logger import get_logger
+from nipoppy.utils import StrOrPathLike
 
 # Apptainer
 APPTAINER_BIND_FLAG = "--bind"
@@ -53,8 +54,8 @@ class ContainerConfig(BaseModel):
 
     def add_bind_path(
         self,
-        path_local: str | Path,
-        path_inside_container: Optional[str | Path] = None,
+        path_local: StrOrPathLike,
+        path_inside_container: Optional[StrOrPathLike] = None,
         mode: str = "rw",
     ):
         """Add a bind path."""
@@ -100,8 +101,8 @@ class ModelWithContainerConfig(BaseModel):
 
 def add_bind_path_to_args(
     args: list[str],
-    path_local: str | Path,
-    path_inside_container: Optional[str | Path] = None,
+    path_local: StrOrPathLike,
+    path_inside_container: Optional[StrOrPathLike] = None,
     mode: Optional[str] = "rw",
 ):
     """Add a bind path to the container arguments.
@@ -110,10 +111,10 @@ def add_bind_path_to_args(
     ----------
     args : list[str]
         Existing arguments
-    path_local : str | Path
+    path_local : StrOrPathLike
         Path on disk. If this is a relative path or contains symlinks,
         it will be resolved
-    path_inside_container : Optional[str  |  Path], optional
+    path_inside_container : Optional[StrOrPathLike], optional
         Path inside the container (if None, will be the same as the local path),
         by default None
     mode : str, optional

--- a/nipoppy_cli/nipoppy/config/container.py
+++ b/nipoppy_cli/nipoppy/config/container.py
@@ -111,10 +111,10 @@ def add_bind_path_to_args(
     ----------
     args : list[str]
         Existing arguments
-    path_local : StrOrPathLike
+    path_local : nipoppy.utils.StrOrPathLike
         Path on disk. If this is a relative path or contains symlinks,
         it will be resolved
-    path_inside_container : Optional[StrOrPathLike], optional
+    path_inside_container : Optional[nipoppy.utils.StrOrPathLike], optional
         Path inside the container (if None, will be the same as the local path),
         by default None
     mode : str, optional

--- a/nipoppy_cli/nipoppy/config/main.py
+++ b/nipoppy_cli/nipoppy/config/main.py
@@ -114,7 +114,7 @@ class Config(ModelWithContainerConfig):
 
         Parameters
         ----------
-        fpath : StrOrPathLike
+        fpath : nipoppy.utils.StrOrPathLike
             Path to the JSON file to write
         """
         fpath = Path(fpath)

--- a/nipoppy_cli/nipoppy/config/main.py
+++ b/nipoppy_cli/nipoppy/config/main.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Self
+from typing import Any, Optional, Self, Union
 
 from pydantic import ConfigDict, Field, model_validator
 
 from nipoppy.config.container import ModelWithContainerConfig
 from nipoppy.config.pipeline import PipelineConfig
-from nipoppy.utils import check_session, load_json
+from nipoppy.utils import StrOrPathLike, check_session, load_json
 
 
 class Config(ModelWithContainerConfig):
@@ -46,7 +46,7 @@ class Config(ModelWithContainerConfig):
     def _propagate_container_config(self) -> Self:
         """Propagate the container config to all pipelines."""
 
-        def _propagate(pipeline_or_pipeline_dicts: dict | PipelineConfig):
+        def _propagate(pipeline_or_pipeline_dicts: Union[dict, PipelineConfig]):
             if isinstance(pipeline_or_pipeline_dicts, PipelineConfig):
                 pipeline_config = pipeline_or_pipeline_dicts
                 container_config = pipeline_config.get_container_config()
@@ -108,12 +108,12 @@ class Config(ModelWithContainerConfig):
                 f"{pipeline_name} {pipeline_version} {pipeline_step}"
             )
 
-    def save(self, fpath: str | Path, **kwargs):
+    def save(self, fpath: StrOrPathLike, **kwargs):
         """Save the config to a JSON file.
 
         Parameters
         ----------
-        fpath : str | Path
+        fpath : StrOrPathLike
             Path to the JSON file to write
         """
         fpath = Path(fpath)
@@ -124,6 +124,6 @@ class Config(ModelWithContainerConfig):
             file.write(self.model_dump_json(**kwargs))
 
     @classmethod
-    def load(cls, path: str | Path) -> Self:
+    def load(cls, path: StrOrPathLike) -> Self:
         """Load a dataset configuration."""
         return cls(**load_json(path))

--- a/nipoppy_cli/nipoppy/config/main.py
+++ b/nipoppy_cli/nipoppy/config/main.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Self
+from typing import Any, Optional
 
 from pydantic import ConfigDict, Field, model_validator
+from typing_extensions import Self
 
 from nipoppy.config.container import ModelWithContainerConfig
 from nipoppy.config.pipeline import PipelineConfig

--- a/nipoppy_cli/nipoppy/config/main.py
+++ b/nipoppy_cli/nipoppy/config/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Self, Union
+from typing import Any, Optional, Self
 
 from pydantic import ConfigDict, Field, model_validator
 
@@ -46,7 +46,7 @@ class Config(ModelWithContainerConfig):
     def _propagate_container_config(self) -> Self:
         """Propagate the container config to all pipelines."""
 
-        def _propagate(pipeline_or_pipeline_dicts: Union[dict, PipelineConfig]):
+        def _propagate(pipeline_or_pipeline_dicts: dict | PipelineConfig):
             if isinstance(pipeline_or_pipeline_dicts, PipelineConfig):
                 pipeline_config = pipeline_or_pipeline_dicts
                 container_config = pipeline_config.get_container_config()

--- a/nipoppy_cli/nipoppy/config/main.py
+++ b/nipoppy_cli/nipoppy/config/main.py
@@ -1,5 +1,7 @@
 """Dataset configuration."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Optional, Self
 

--- a/nipoppy_cli/nipoppy/config/pipeline.py
+++ b/nipoppy_cli/nipoppy/config/pipeline.py
@@ -1,8 +1,10 @@
 """Pipeline configuration."""
 
+from __future__ import annotations
+
 import re
 from pathlib import Path
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence
 
 from pydantic import ConfigDict, model_validator
 
@@ -57,7 +59,7 @@ class PipelineConfig(ModelWithContainerConfig):
 
     def add_pybids_ignore_patterns(
         self,
-        patterns: Union[Sequence[Union[str, re.Pattern]], str, re.Pattern],
+        patterns: Sequence[str | re.Pattern] | str | re.Pattern,
     ):
         """Add pattern(s) to ignore for PyBIDS."""
         if isinstance(patterns, (str, re.Pattern)):

--- a/nipoppy_cli/nipoppy/config/pipeline.py
+++ b/nipoppy_cli/nipoppy/config/pipeline.py
@@ -2,7 +2,7 @@
 
 import re
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from pydantic import ConfigDict, model_validator
 
@@ -57,7 +57,7 @@ class PipelineConfig(ModelWithContainerConfig):
 
     def add_pybids_ignore_patterns(
         self,
-        patterns: Sequence[str | re.Pattern] | str | re.Pattern,
+        patterns: Union[Sequence[Union[str, re.Pattern]], str, re.Pattern],
     ):
         """Add pattern(s) to ignore for PyBIDS."""
         if isinstance(patterns, (str, re.Pattern)):

--- a/nipoppy_cli/nipoppy/layout.py
+++ b/nipoppy_cli/nipoppy/layout.py
@@ -142,9 +142,9 @@ class DatasetLayout(Base):
 
         Parameters
         ----------
-        dpath_root : StrOrPathLike
+        dpath_root : nipoppy.utils.StrOrPathLike
             Path to the root directory of the dataset.
-        fpath_config : Optional[StrOrPathLike], optional
+        fpath_config : Optional[nipoppy.utils.StrOrPathLike], optional
             Path to the layout config to use, by default None.
             If None, the default layout will be used.
 

--- a/nipoppy_cli/nipoppy/layout.py
+++ b/nipoppy_cli/nipoppy/layout.py
@@ -7,7 +7,12 @@ from typing import Any, Optional, Tuple
 from pydantic import BaseModel, ConfigDict, Field
 
 from nipoppy.base import Base
-from nipoppy.utils import FPATH_DEFAULT_LAYOUT, get_pipeline_tag, load_json
+from nipoppy.utils import (
+    FPATH_DEFAULT_LAYOUT,
+    StrOrPathLike,
+    get_pipeline_tag,
+    load_json,
+)
 
 
 class PathInfo(BaseModel):
@@ -129,17 +134,24 @@ class DatasetLayout(Base):
     """File/directory structure for a specific dataset."""
 
     def __init__(
-        self, dpath_root: Path | str, fpath_config: Optional[Path | str] = None
+        self,
+        dpath_root: StrOrPathLike,
+        fpath_config: Optional[StrOrPathLike] = None,
     ):
         """Initialize the object.
 
         Parameters
         ----------
-        dataset_root: Path | str
+        dpath_root : StrOrPathLike
             Path to the root directory of the dataset.
-        fpath_config: Path | str | None
-            Path to layout config to use, by default None.
+        fpath_config : Optional[StrOrPathLike], optional
+            Path to the layout config to use, by default None.
             If None, the default layout will be used.
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``fpath_config`` does not exist.
         """
         # use the default layout if none is specified
         if fpath_config is None:
@@ -187,7 +199,7 @@ class DatasetLayout(Base):
         self.dname_pipeline_work = "work"
         self.dname_pipeline_output = "output"
 
-    def get_full_path(self, path: str | Path) -> Path:
+    def get_full_path(self, path: StrOrPathLike) -> Path:
         """Build a full path from a relative path."""
         return self.dpath_root / path
 

--- a/nipoppy_cli/nipoppy/logger.py
+++ b/nipoppy_cli/nipoppy/logger.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 from rich.logging import RichHandler
 
+from nipoppy.utils import StrOrPathLike
+
 DATE_FORMAT = "[%Y-%m-%d %X]"
 FORMAT_RICH = "%(message)s"
 FORMAT_FILE = "%(asctime)s %(levelname)-7s %(message)s"
@@ -23,7 +25,7 @@ def get_logger(name: Optional[str] = None, level: int = logging.INFO) -> logging
     return logging.getLogger(name=name)
 
 
-def add_logfile(logger: logging.Logger, fpath_log: Path | str) -> None:
+def add_logfile(logger: logging.Logger, fpath_log: StrOrPathLike) -> None:
     """Add a file handler to the logger."""
     fpath_log = Path(fpath_log)
 

--- a/nipoppy_cli/nipoppy/tabular/base.py
+++ b/nipoppy_cli/nipoppy/tabular/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Optional, Self, Sequence, Union
+from typing import Any, Optional, Self, Sequence
 
 import pandas as pd
 from pydantic import BaseModel, ValidationError, model_validator
@@ -158,9 +158,7 @@ class BaseTabular(pd.DataFrame, ABC):
 
         return diff
 
-    def add_or_update_records(
-        self, records: Union[list[dict], dict], validate=True
-    ) -> Self:
+    def add_or_update_records(self, records: list[dict] | dict, validate=True) -> Self:
         """Add or update records."""
         if isinstance(records, dict):
             records = [records]
@@ -199,7 +197,7 @@ class BaseTabular(pd.DataFrame, ABC):
         use_relative_path=True,
         sort=True,
         dry_run=False,
-    ) -> Union[Path, None]:
+    ) -> Path | None:
         """Save the dataframe to a file with a backup."""
         tabular_new = self.sort_values() if sort else self
         if fpath_symlink.exists():

--- a/nipoppy_cli/nipoppy/tabular/base.py
+++ b/nipoppy_cli/nipoppy/tabular/base.py
@@ -1,5 +1,7 @@
 """Generic class for tabular data."""
 
+from __future__ import annotations
+
 import contextlib
 from abc import ABC, abstractmethod
 from pathlib import Path

--- a/nipoppy_cli/nipoppy/tabular/base.py
+++ b/nipoppy_cli/nipoppy/tabular/base.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import contextlib
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Optional, Self, Sequence
+from typing import Any, Optional, Sequence
 
 import pandas as pd
 from pydantic import BaseModel, ValidationError, model_validator
+from typing_extensions import Self
 
 from nipoppy.utils import StrOrPathLike, save_df_with_backup
 

--- a/nipoppy_cli/nipoppy/tabular/base.py
+++ b/nipoppy_cli/nipoppy/tabular/base.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import contextlib
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Optional, Self, Sequence
+from typing import Any, Optional, Self, Sequence, Union
 
 import pandas as pd
 from pydantic import BaseModel, ValidationError, model_validator
 
-from nipoppy.utils import save_df_with_backup
+from nipoppy.utils import StrOrPathLike, save_df_with_backup
 
 
 class BaseTabularModel(BaseModel):
@@ -79,7 +79,7 @@ class BaseTabular(pd.DataFrame, ABC):
         raise NotImplementedError("model must be assigned in subclass")
 
     @classmethod
-    def load(cls, fpath: str | Path, validate=True, **kwargs) -> Self:
+    def load(cls, fpath: StrOrPathLike, validate=True, **kwargs) -> Self:
         """Load (and optionally validate) a tabular data file."""
         if "dtype" in kwargs:
             raise ValueError(
@@ -158,7 +158,9 @@ class BaseTabular(pd.DataFrame, ABC):
 
         return diff
 
-    def add_or_update_records(self, records: list[dict] | dict, validate=True) -> Self:
+    def add_or_update_records(
+        self, records: Union[list[dict], dict], validate=True
+    ) -> Self:
         """Add or update records."""
         if isinstance(records, dict):
             records = [records]
@@ -192,12 +194,12 @@ class BaseTabular(pd.DataFrame, ABC):
 
     def save_with_backup(
         self,
-        fpath_symlink: str | Path,
+        fpath_symlink: StrOrPathLike,
         dname_backups: Optional[str] = None,
         use_relative_path=True,
         sort=True,
         dry_run=False,
-    ) -> Path | None:
+    ) -> Union[Path, None]:
         """Save the dataframe to a file with a backup."""
         tabular_new = self.sort_values() if sort else self
         if fpath_symlink.exists():

--- a/nipoppy_cli/nipoppy/tabular/doughnut.py
+++ b/nipoppy_cli/nipoppy/tabular/doughnut.py
@@ -12,6 +12,7 @@ from nipoppy.logger import get_logger
 from nipoppy.tabular.manifest import Manifest, ManifestModel
 from nipoppy.utils import (
     FIELD_DESCRIPTION_MAP,
+    StrOrPathLike,
     participant_id_to_bids_id,
     participant_id_to_dicom_id,
 )
@@ -147,9 +148,9 @@ class Doughnut(Manifest):
 
 def generate_doughnut(
     manifest: Manifest,
-    dpath_downloaded: Optional[str | Path] = None,
-    dpath_organized: Optional[str | Path] = None,
-    dpath_bidsified: Optional[str | Path] = None,
+    dpath_downloaded: Optional[StrOrPathLike] = None,
+    dpath_organized: Optional[StrOrPathLike] = None,
+    dpath_bidsified: Optional[StrOrPathLike] = None,
     empty=False,
     logger: Optional[logging.Logger] = None,
     # TODO allow custom map from participant_id to participant_dicom_dir
@@ -157,7 +158,7 @@ def generate_doughnut(
     """Generate a doughnut object."""
 
     def check_status(
-        dpath: Optional[str | Path],
+        dpath: Optional[StrOrPathLike],
         participant_dname: str,
         session: str,
         session_first=False,
@@ -244,9 +245,9 @@ def generate_doughnut(
 def update_doughnut(
     doughnut: Doughnut,
     manifest: Manifest,
-    dpath_downloaded: Optional[str | Path] = None,
-    dpath_organized: Optional[str | Path] = None,
-    dpath_bidsified: Optional[str | Path] = None,
+    dpath_downloaded: Optional[StrOrPathLike] = None,
+    dpath_organized: Optional[StrOrPathLike] = None,
+    dpath_bidsified: Optional[StrOrPathLike] = None,
     empty=False,
     logger: Optional[logging.Logger] = None,
 ) -> Doughnut:

--- a/nipoppy_cli/nipoppy/tabular/doughnut.py
+++ b/nipoppy_cli/nipoppy/tabular/doughnut.py
@@ -1,5 +1,7 @@
 """Class for the doughnut file."""
 
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Optional, Self

--- a/nipoppy_cli/nipoppy/tabular/doughnut.py
+++ b/nipoppy_cli/nipoppy/tabular/doughnut.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional, Self
+from typing import Optional
 
 from pydantic import Field
+from typing_extensions import Self
 
 from nipoppy.logger import get_logger
 from nipoppy.tabular.manifest import Manifest, ManifestModel

--- a/nipoppy_cli/nipoppy/tabular/manifest.py
+++ b/nipoppy_cli/nipoppy/tabular/manifest.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Optional, Self
+from typing import Optional
 
 import pandas as pd
 from pydantic import ConfigDict, Field
+from typing_extensions import Self
 
 from nipoppy.tabular.base import BaseTabular, BaseTabularModel
 from nipoppy.utils import FIELD_DESCRIPTION_MAP

--- a/nipoppy_cli/nipoppy/tabular/manifest.py
+++ b/nipoppy_cli/nipoppy/tabular/manifest.py
@@ -1,5 +1,7 @@
 """Class for the dataset manifest."""
 
+from __future__ import annotations
+
 from typing import Optional, Self
 
 import pandas as pd

--- a/nipoppy_cli/nipoppy/utils.py
+++ b/nipoppy_cli/nipoppy/utils.py
@@ -142,7 +142,7 @@ def load_json(fpath: StrOrPathLike, **kwargs) -> dict:
 
     Parameters
     ----------
-    fpath : StrOrPathLike
+    fpath : nipoppy.utils.StrOrPathLike
         Path to the JSON file
     **kwargs :
         Keyword arguments to pass to json.load
@@ -163,7 +163,7 @@ def save_json(obj: dict, fpath: StrOrPathLike, **kwargs):
     ----------
     obj : dict
         The JSON object
-    fpath : StrOrPathLike
+    fpath : nipoppy.utils.StrOrPathLike
         Path to the JSON file to write
     indent : int, optional
         Indentation level, by default 4
@@ -206,7 +206,7 @@ def save_df_with_backup(
     ----------
     df : pd.DataFrame
         The dataframe to save
-    fpath_symlink : StrOrPathLike
+    fpath_symlink : nipoppy.utils.StrOrPathLike
         The path to the symlink
     dname_backups : Optional[str], optional
         The directory where the timestamped backup file should be written

--- a/nipoppy_cli/nipoppy/utils.py
+++ b/nipoppy_cli/nipoppy/utils.py
@@ -5,10 +5,12 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypeVar, Union
 
 import bids
 import pandas as pd
+
+StrOrPathLike = TypeVar("StrOrPathLike", str, os.PathLike)
 
 # BIDS
 BIDS_SUBJECT_PREFIX = "sub-"
@@ -85,11 +87,13 @@ def strip_session(session: Optional[str]):
 
 
 def create_bids_db(
-    dpath_bids: Path | str,
-    dpath_bids_db: Optional[Path | str] = None,
+    dpath_bids: StrOrPathLike,
+    dpath_bids_db: Optional[StrOrPathLike] = None,
     validate=False,
     reset_database=True,
-    ignore_patterns: Optional[list[str | re.Pattern] | str | re.Pattern] = None,
+    ignore_patterns: Optional[
+        Union[list[Union[str, re.Pattern]], str, re.Pattern]
+    ] = None,
     resolve_paths=True,
 ) -> bids.BIDSLayout:
     """Create a BIDSLayout using an indexer."""
@@ -133,12 +137,12 @@ def get_pipeline_tag(
     return sep.join(components)
 
 
-def load_json(fpath: str | Path, **kwargs) -> dict:
+def load_json(fpath: StrOrPathLike, **kwargs) -> dict:
     """Load a JSON file.
 
     Parameters
     ----------
-    fpath : str | Path
+    fpath : StrOrPathLike
         Path to the JSON file
     **kwargs :
         Keyword arguments to pass to json.load
@@ -152,14 +156,14 @@ def load_json(fpath: str | Path, **kwargs) -> dict:
         return json.load(file, **kwargs)
 
 
-def save_json(obj: dict, fpath: str | Path, **kwargs):
+def save_json(obj: dict, fpath: StrOrPathLike, **kwargs):
     """Save a JSON object to a file.
 
     Parameters
     ----------
     obj : dict
         The JSON object
-    fpath : str | Path
+    fpath : StrOrPathLike
         Path to the JSON file to write
     indent : int, optional
         Indentation level, by default 4
@@ -174,14 +178,14 @@ def save_json(obj: dict, fpath: str | Path, **kwargs):
         json.dump(obj, file, **kwargs)
 
 
-def add_path_suffix(path: Path | str, suffix: str, sep="-") -> Path:
+def add_path_suffix(path: StrOrPathLike, suffix: str, sep="-") -> Path:
     """Add a suffix to a path, before the last file extension (if any)."""
     path = Path(path)
     return Path(path.parent, f"{path.stem}{sep}{suffix}{path.suffix}")
 
 
 def add_path_timestamp(
-    path: Path | str, timestamp_format="%Y%m%d_%H%M", sep="-"
+    path: StrOrPathLike, timestamp_format="%Y%m%d_%H%M", sep="-"
 ) -> Path:
     """Add a timestamp to a path, before the last file extension (if any)."""
     timestamp = datetime.datetime.now().strftime(timestamp_format)
@@ -190,19 +194,19 @@ def add_path_timestamp(
 
 def save_df_with_backup(
     df: pd.DataFrame,
-    fpath_symlink: str | Path,
+    fpath_symlink: StrOrPathLike,
     dname_backups: Optional[str] = None,
     use_relative_path=True,
     dry_run=False,
     **kwargs,
-) -> Path | None:
+) -> Union[Path, None]:
     """Save a dataframe as a symlink pointing to a timestamped "backup" file.
 
     Parameters
     ----------
     df : pd.DataFrame
         The dataframe to save
-    fpath_symlink : str | Path
+    fpath_symlink : StrOrPathLike
         The path to the symlink
     dname_backups : Optional[str], optional
         The directory where the timestamped backup file should be written

--- a/nipoppy_cli/nipoppy/utils.py
+++ b/nipoppy_cli/nipoppy/utils.py
@@ -1,11 +1,13 @@
 """Utility functions."""
 
+from __future__ import annotations
+
 import datetime
 import json
 import os
 import re
 from pathlib import Path
-from typing import Optional, TypeVar, Union
+from typing import Optional, TypeVar
 
 import bids
 import pandas as pd
@@ -91,9 +93,7 @@ def create_bids_db(
     dpath_bids_db: Optional[StrOrPathLike] = None,
     validate=False,
     reset_database=True,
-    ignore_patterns: Optional[
-        Union[list[Union[str, re.Pattern]], str, re.Pattern]
-    ] = None,
+    ignore_patterns: Optional[list[str | re.Pattern] | str | re.Pattern] = None,
     resolve_paths=True,
 ) -> bids.BIDSLayout:
     """Create a BIDSLayout using an indexer."""
@@ -199,7 +199,7 @@ def save_df_with_backup(
     use_relative_path=True,
     dry_run=False,
     **kwargs,
-) -> Union[Path, None]:
+) -> Path | None:
     """Save a dataframe as a symlink pointing to a timestamped "backup" file.
 
     Parameters

--- a/nipoppy_cli/nipoppy/workflows/base.py
+++ b/nipoppy_cli/nipoppy/workflows/base.py
@@ -1,5 +1,7 @@
 """Workflow utilities."""
 
+from __future__ import annotations
+
 import logging
 import os
 import shlex
@@ -8,7 +10,7 @@ import subprocess
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence
 
 from nipoppy.base import Base
 from nipoppy.config.main import Config
@@ -65,7 +67,7 @@ class BaseWorkflow(Base, ABC):
 
     def generate_fpath_log(
         self,
-        dnames_parent: Optional[Union[str, list[str]]] = None,
+        dnames_parent: Optional[str | list[str]] = None,
         fname_stem: Optional[str] = None,
     ) -> Path:
         """Generate a log file path."""
@@ -86,10 +88,10 @@ class BaseWorkflow(Base, ABC):
 
     def run_command(
         self,
-        command_or_args: Union[Sequence[str], str],
+        command_or_args: Sequence[str] | str,
         check=True,
         **kwargs,
-    ) -> Union[subprocess.Popen, str]:
+    ) -> subprocess.Popen | str:
         """Run a command in a subprocess.
 
         The command's stdout and stderr outputs are written to the log
@@ -101,7 +103,7 @@ class BaseWorkflow(Base, ABC):
 
         Parameters
         ----------
-        command_or_args : Union[Sequence[str], str]
+        command_or_args : Sequence[str]  |  str
             The command to run.
         check : bool, optional
             If True, raise an error if the process exits with a non-zero code,

--- a/nipoppy_cli/nipoppy/workflows/base.py
+++ b/nipoppy_cli/nipoppy/workflows/base.py
@@ -45,7 +45,7 @@ class BaseWorkflow(Base, ABC):
 
         Parameters
         ----------
-        dpath_root : StrOrPathLike
+        dpath_root : nipoppy.utils.StrOrPathLike
             Path the the root directory of the dataset.
         name : str
             Name of the workflow, used for logging.

--- a/nipoppy_cli/nipoppy/workflows/base.py
+++ b/nipoppy_cli/nipoppy/workflows/base.py
@@ -37,7 +37,7 @@ class BaseWorkflow(Base, ABC):
         self,
         dpath_root: StrOrPathLike,
         name: str,
-        fpath_layout: Optional[Path] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run=False,
     ):

--- a/nipoppy_cli/nipoppy/workflows/base.py
+++ b/nipoppy_cli/nipoppy/workflows/base.py
@@ -8,7 +8,7 @@ import subprocess
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 from nipoppy.base import Base
 from nipoppy.config.main import Config
@@ -17,7 +17,7 @@ from nipoppy.logger import get_logger
 from nipoppy.tabular.base import BaseTabular
 from nipoppy.tabular.doughnut import Doughnut, generate_doughnut
 from nipoppy.tabular.manifest import Manifest
-from nipoppy.utils import add_path_timestamp
+from nipoppy.utils import StrOrPathLike, add_path_timestamp
 
 LOG_SUFFIX = ".log"
 
@@ -33,7 +33,7 @@ class BaseWorkflow(Base, ABC):
 
     def __init__(
         self,
-        dpath_root: Path | str,
+        dpath_root: StrOrPathLike,
         name: str,
         fpath_layout: Optional[Path] = None,
         logger: Optional[logging.Logger] = None,
@@ -43,7 +43,7 @@ class BaseWorkflow(Base, ABC):
 
         Parameters
         ----------
-        dpath_root : Path | str
+        dpath_root : StrOrPathLike
             Path the the root directory of the dataset.
         name : str
             Name of the workflow, used for logging.
@@ -65,7 +65,7 @@ class BaseWorkflow(Base, ABC):
 
     def generate_fpath_log(
         self,
-        dnames_parent: Optional[str | list[str]] = None,
+        dnames_parent: Optional[Union[str, list[str]]] = None,
         fname_stem: Optional[str] = None,
     ) -> Path:
         """Generate a log file path."""
@@ -86,10 +86,10 @@ class BaseWorkflow(Base, ABC):
 
     def run_command(
         self,
-        command_or_args: Sequence[str] | str,
+        command_or_args: Union[Sequence[str], str],
         check=True,
         **kwargs,
-    ) -> subprocess.Popen | str:
+    ) -> Union[subprocess.Popen, str]:
         """Run a command in a subprocess.
 
         The command's stdout and stderr outputs are written to the log
@@ -101,7 +101,7 @@ class BaseWorkflow(Base, ABC):
 
         Parameters
         ----------
-        command_or_args : Sequence[str] | str
+        command_or_args : Union[Sequence[str], str]
             The command to run.
         check : bool, optional
             If True, raise an error if the process exits with a non-zero code,
@@ -111,7 +111,7 @@ class BaseWorkflow(Base, ABC):
 
         Returns
         -------
-        subprocess.Popen | str
+        subprocess.Popen or str
         """
 
         def process_output(

--- a/nipoppy_cli/nipoppy/workflows/bids_conversion.py
+++ b/nipoppy_cli/nipoppy/workflows/bids_conversion.py
@@ -24,7 +24,7 @@ class BidsConversionRunner(PipelineRunner):
         participant: str = None,
         session: str = None,
         simulate: bool = False,
-        fpath_layout: Optional[Path] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run: bool = False,
     ):

--- a/nipoppy_cli/nipoppy/workflows/bids_conversion.py
+++ b/nipoppy_cli/nipoppy/workflows/bids_conversion.py
@@ -3,10 +3,10 @@
 import logging
 from functools import cached_property
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from nipoppy.config.pipeline import PipelineConfig
-from nipoppy.utils import get_pipeline_tag
+from nipoppy.utils import StrOrPathLike, get_pipeline_tag
 from nipoppy.workflows.runner import PipelineRunner
 
 
@@ -15,7 +15,7 @@ class BidsConversionRunner(PipelineRunner):
 
     def __init__(
         self,
-        dpath_root: Path | str,
+        dpath_root: StrOrPathLike,
         pipeline_name: str,
         pipeline_version: str,
         pipeline_step: str,
@@ -96,7 +96,7 @@ class BidsConversionRunner(PipelineRunner):
 
     def generate_fpath_log(
         self,
-        dname_parent: Optional[str | list[str]] = None,
+        dname_parent: Optional[Union[str, list[str]]] = None,
         fname_stem: Optional[str] = None,
     ) -> Path:
         """Generate a log file path."""

--- a/nipoppy_cli/nipoppy/workflows/bids_conversion.py
+++ b/nipoppy_cli/nipoppy/workflows/bids_conversion.py
@@ -1,9 +1,11 @@
 """Workflow for convert command."""
 
+from __future__ import annotations
+
 import logging
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 from nipoppy.config.pipeline import PipelineConfig
 from nipoppy.utils import StrOrPathLike, get_pipeline_tag
@@ -96,7 +98,7 @@ class BidsConversionRunner(PipelineRunner):
 
     def generate_fpath_log(
         self,
-        dname_parent: Optional[Union[str, list[str]]] = None,
+        dname_parent: Optional[str | list[str]] = None,
         fname_stem: Optional[str] = None,
     ) -> Path:
         """Generate a log file path."""

--- a/nipoppy_cli/nipoppy/workflows/dataset_init.py
+++ b/nipoppy_cli/nipoppy/workflows/dataset_init.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from nipoppy.utils import FPATH_SAMPLE_CONFIG, FPATH_SAMPLE_MANIFEST
+from nipoppy.utils import FPATH_SAMPLE_CONFIG, FPATH_SAMPLE_MANIFEST, StrOrPathLike
 from nipoppy.workflows.base import BaseWorkflow
 
 
@@ -17,7 +17,7 @@ class InitWorkflow(BaseWorkflow):
     def __init__(
         self,
         dpath_root: Path,
-        fpath_layout: Optional[Path] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run: bool = False,
     ):

--- a/nipoppy_cli/nipoppy/workflows/dicom_reorg.py
+++ b/nipoppy_cli/nipoppy/workflows/dicom_reorg.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from nipoppy.utils import StrOrPathLike
 from nipoppy.workflows.base import BaseWorkflow
 
 
@@ -13,7 +14,7 @@ class DicomReorgWorkflow(BaseWorkflow):
 
     def __init__(
         self,
-        dpath_root: Path | str,
+        dpath_root: StrOrPathLike,
         copy_files: bool = False,
         fpath_layout: Optional[Path] = None,
         logger: Optional[logging.Logger] = None,

--- a/nipoppy_cli/nipoppy/workflows/dicom_reorg.py
+++ b/nipoppy_cli/nipoppy/workflows/dicom_reorg.py
@@ -16,7 +16,7 @@ class DicomReorgWorkflow(BaseWorkflow):
         self,
         dpath_root: StrOrPathLike,
         copy_files: bool = False,
-        fpath_layout: Optional[Path] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run: bool = False,
     ):

--- a/nipoppy_cli/nipoppy/workflows/doughnut.py
+++ b/nipoppy_cli/nipoppy/workflows/doughnut.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 from nipoppy.tabular.doughnut import Doughnut, generate_doughnut, update_doughnut
+from nipoppy.utils import StrOrPathLike
 from nipoppy.workflows.base import BaseWorkflow
 
 
@@ -16,7 +17,7 @@ class DoughnutWorkflow(BaseWorkflow):
         dpath_root: Path,
         empty: bool = False,
         regenerate: bool = False,
-        fpath_layout: Optional[Path] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run: bool = False,
     ):

--- a/nipoppy_cli/nipoppy/workflows/pipeline.py
+++ b/nipoppy_cli/nipoppy/workflows/pipeline.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import bids
 from pydantic import ValidationError
@@ -19,6 +19,7 @@ from nipoppy.utils import (
     BIDS_SESSION_PREFIX,
     BIDS_SUBJECT_PREFIX,
     DPATH_DESCRIPTORS,
+    StrOrPathLike,
     check_participant,
     check_session,
     create_bids_db,
@@ -36,13 +37,13 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
 
     def __init__(
         self,
-        dpath_root: Path | str,
+        dpath_root: StrOrPathLike,
         name: str,
         pipeline_name: str,
         pipeline_version: str,
         participant: str = None,
         session: str = None,
-        fpath_layout: Optional[Path | str] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run=False,
     ):
@@ -114,7 +115,9 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
             )
         return fpath_container
 
-    def _check_files_for_json(self, fpaths: str | Path | list[str | Path]) -> dict:
+    def _check_files_for_json(
+        self, fpaths: Union[StrOrPathLike, list[StrOrPathLike]]
+    ) -> dict:
         if isinstance(fpaths, (str, Path)):
             fpaths = [fpaths]
         for fpath in fpaths:
@@ -272,7 +275,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
 
     def set_up_bids_db(
         self,
-        dpath_bids_db: Path | str,
+        dpath_bids_db: StrOrPathLike,
         participant: Optional[str] = None,
         session: Optional[str] = None,
     ) -> bids.BIDSLayout:
@@ -381,7 +384,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
 
     def generate_fpath_log(
         self,
-        dnames_parent: Optional[str | list[str]] = None,
+        dnames_parent: Optional[Union[str, list[str]]] = None,
         fname_stem: Optional[str] = None,
     ) -> Path:
         """Generate a log file path."""

--- a/nipoppy_cli/nipoppy/workflows/pipeline.py
+++ b/nipoppy_cli/nipoppy/workflows/pipeline.py
@@ -1,11 +1,13 @@
 """Base class for pipeline workflows."""
 
+from __future__ import annotations
+
 import json
 import logging
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import bids
 from pydantic import ValidationError
@@ -116,7 +118,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
         return fpath_container
 
     def _check_files_for_json(
-        self, fpaths: Union[StrOrPathLike, list[StrOrPathLike]]
+        self, fpaths: StrOrPathLike | list[StrOrPathLike]
     ) -> dict:
         if isinstance(fpaths, (str, Path)):
             fpaths = [fpaths]
@@ -384,7 +386,7 @@ class BasePipelineWorkflow(BaseWorkflow, ABC):
 
     def generate_fpath_log(
         self,
-        dnames_parent: Optional[Union[str, list[str]]] = None,
+        dnames_parent: Optional[str | list[str]] = None,
         fname_stem: Optional[str] = None,
     ) -> Path:
         """Generate a log file path."""

--- a/nipoppy_cli/nipoppy/workflows/runner.py
+++ b/nipoppy_cli/nipoppy/workflows/runner.py
@@ -8,6 +8,7 @@ from boutiques import bosh
 
 from nipoppy.config.boutiques import BoutiquesConfig
 from nipoppy.config.container import ContainerConfig, prepare_container
+from nipoppy.utils import StrOrPathLike
 from nipoppy.workflows.pipeline import BasePipelineWorkflow
 
 
@@ -16,7 +17,7 @@ class PipelineRunner(BasePipelineWorkflow):
 
     def __init__(
         self,
-        dpath_root: Path | str,
+        dpath_root: StrOrPathLike,
         pipeline_name: str,
         pipeline_version: str,
         participant: str = None,
@@ -46,7 +47,7 @@ class PipelineRunner(BasePipelineWorkflow):
         self,
         participant: str,
         session: str,
-        bind_paths: Optional[list[str | Path]] = None,
+        bind_paths: Optional[list[StrOrPathLike]] = None,
     ) -> str:
         """Update container config and generate container command."""
         if bind_paths is None:

--- a/nipoppy_cli/nipoppy/workflows/runner.py
+++ b/nipoppy_cli/nipoppy/workflows/runner.py
@@ -1,7 +1,6 @@
 """PipelineRunner workflow."""
 
 import logging
-from pathlib import Path
 from typing import Optional
 
 from boutiques import bosh
@@ -23,7 +22,7 @@ class PipelineRunner(BasePipelineWorkflow):
         participant: str = None,
         session: str = None,
         simulate: bool = False,
-        fpath_layout: Optional[Path] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run: bool = False,
     ):

--- a/nipoppy_cli/nipoppy/workflows/tracker.py
+++ b/nipoppy_cli/nipoppy/workflows/tracker.py
@@ -1,7 +1,6 @@
 """PipelineTracker workflow."""
 
 import logging
-from pathlib import Path
 from typing import Optional
 
 from nipoppy.tabular.bagel import Bagel
@@ -19,7 +18,7 @@ class PipelineTracker(BasePipelineWorkflow):
         pipeline_version: str,
         participant: str = None,
         session: str = None,
-        fpath_layout: Optional[Path] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run: bool = False,
     ):

--- a/nipoppy_cli/nipoppy/workflows/tracker.py
+++ b/nipoppy_cli/nipoppy/workflows/tracker.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 from nipoppy.tabular.bagel import Bagel
+from nipoppy.utils import StrOrPathLike
 from nipoppy.workflows.pipeline import BasePipelineWorkflow
 
 
@@ -13,7 +14,7 @@ class PipelineTracker(BasePipelineWorkflow):
 
     def __init__(
         self,
-        dpath_root: Path | str,
+        dpath_root: StrOrPathLike,
         pipeline_name: str,
         pipeline_version: str,
         participant: str = None,

--- a/nipoppy_cli/pyproject.toml
+++ b/nipoppy_cli/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pydantic",
     "rich",
     "rich_argparse",
+    "typing-extensions",
 ]
 description = "Standardized organization and processing of neuroimaging-clinical datasets"
 license = { file = "LICENSE" }

--- a/nipoppy_cli/pyproject.toml
+++ b/nipoppy_cli/pyproject.toml
@@ -42,7 +42,7 @@ doc = [
     "pygments-csv-lexer>=0.1.3",
     "sphinx>=7.2.6",
     "sphinx-argparse>=0.4.0",
-    "sphinx-autoapi>=3.0.0",
+    "sphinx-autoapi==3.0.0",
     "sphinx-copybutton>=0.5.2",
     "sphinx-jsonschema>=1.19.1",
     "sphinx-togglebutton>=0.3.2",

--- a/nipoppy_cli/pyproject.toml
+++ b/nipoppy_cli/pyproject.toml
@@ -31,7 +31,7 @@ description = "Standardized organization and processing of neuroimaging-clinical
 license = { file = "LICENSE" }
 name = "nipoppy"
 readme = "../README.md"
-# TODO requires_python
+requires-python = ">=3.9"
 version = "1.0.0" # TODO eventually use dynamic versioning
 
 [project.optional-dependencies]
@@ -48,12 +48,7 @@ doc = [
     "mdit-py-plugins>=0.4.0",
     "myst-parser>=2.0.0",
 ]
-test = [
-    "pytest>=6.0.0",
-    "pytest-cov",
-    "pytest-mock",
-    "fids>=0.1.0",
-]
+test = ["pytest>=6.0.0", "pytest-cov", "pytest-mock", "fids>=0.1.0"]
 tests = ["nipoppy[test]"] # alias in case of typo
 
 [project.scripts]

--- a/nipoppy_cli/tests/conftest.py
+++ b/nipoppy_cli/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -13,7 +13,7 @@ from fids.fids import create_fake_bids_dataset
 from nipoppy.config.main import Config
 from nipoppy.tabular.doughnut import Doughnut
 from nipoppy.tabular.manifest import Manifest
-from nipoppy.utils import strip_session
+from nipoppy.utils import StrOrPathLike, strip_session
 
 FPATH_CONFIG = "proc/global_configs.json"
 FPATH_MANIFEST = "tabular/manifest.csv"
@@ -110,7 +110,7 @@ def create_empty_dataset(dpath_root: Path):
 def _process_participants_sessions(
     participants_and_sessions: Optional[dict[str, list[str]]] = None,
     participants: Optional[list[str]] = None,
-    sessions: Optional[list[str] | dict[str, list[str]]] = None,
+    sessions: Optional[Union[list[str], dict[str, list[str]]]] = None,
 ):
     """Process participant/session arguments."""
     if participants_and_sessions is None:
@@ -125,7 +125,7 @@ def _process_participants_sessions(
 
 
 def _fake_dicoms(
-    dpath: str | Path,
+    dpath: StrOrPathLike,
     participants_and_sessions: Optional[dict[str, list[str]]] = None,
     participants: Optional[list[str]] = None,
     sessions: Optional[list[str]] = None,
@@ -189,7 +189,7 @@ def _fake_dicoms(
 
 
 def fake_dicoms_downloaded(
-    dpath: str | Path,
+    dpath: StrOrPathLike,
     participants_and_sessions: Optional[dict[str, list[str]]] = None,
     participants: Optional[list[str]] = None,
     sessions: Optional[list[str]] = None,
@@ -220,7 +220,7 @@ def fake_dicoms_downloaded(
 
 
 def fake_dicoms_organized(
-    dpath: str | Path,
+    dpath: StrOrPathLike,
     participants_and_sessions: Optional[dict[str, list[str]]] = None,
     participants: Optional[list[str]] = None,
     sessions: Optional[list[str]] = None,
@@ -253,9 +253,9 @@ def prepare_dataset(
     participants_and_sessions_downloaded: Optional[dict[str, list[str]]] = None,
     participants_and_sessions_organized: Optional[dict[str, list[str]]] = None,
     participants_and_sessions_bidsified: Optional[dict[str, list[str]]] = None,
-    dpath_downloaded: Optional[str | Path] = None,
-    dpath_organized: Optional[str | Path] = None,
-    dpath_bidsified: Optional[str | Path] = None,
+    dpath_downloaded: Optional[StrOrPathLike] = None,
+    dpath_organized: Optional[StrOrPathLike] = None,
+    dpath_bidsified: Optional[StrOrPathLike] = None,
 ):
     """Create dummy imaging files for testing the DICOM-to-BIDS conversion process."""
     # create the manifest

--- a/nipoppy_cli/tests/conftest.py
+++ b/nipoppy_cli/tests/conftest.py
@@ -1,8 +1,10 @@
 """Utilities for tests."""
 
+from __future__ import annotations
+
 import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -110,7 +112,7 @@ def create_empty_dataset(dpath_root: Path):
 def _process_participants_sessions(
     participants_and_sessions: Optional[dict[str, list[str]]] = None,
     participants: Optional[list[str]] = None,
-    sessions: Optional[Union[list[str], dict[str, list[str]]]] = None,
+    sessions: Optional[list[str] | dict[str, list[str]]] = None,
 ):
     """Process participant/session arguments."""
     if participants_and_sessions is None:

--- a/nipoppy_cli/tests/test_tabular_base.py
+++ b/nipoppy_cli/tests/test_tabular_base.py
@@ -189,7 +189,7 @@ def test_concatenate_error(data1: list[dict], data2: list[dict]):
 )
 def test_save_with_backup(
     fname: str,
-    dname_backups: str | None,
+    dname_backups: Optional[str],
     dname_backups_processed: str,
     tmp_path: Path,
 ):

--- a/nipoppy_cli/tests/test_tabular_doughnut.py
+++ b/nipoppy_cli/tests/test_tabular_doughnut.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from nipoppy.tabular.doughnut import Doughnut, generate_doughnut, update_doughnut
+from nipoppy.utils import StrOrPathLike
 
 from .conftest import DPATH_TEST_DATA, check_doughnut, prepare_dataset
 
@@ -176,9 +177,9 @@ def test_generate_and_update(
     participants_and_sessions_downloaded: dict[str, list[str]],
     participants_and_sessions_organized: dict[str, list[str]],
     participants_and_sessions_bidsified: dict[str, list[str]],
-    dpath_downloaded_relative: str | Path,
-    dpath_organized_relative: str | Path,
-    dpath_bidsified_relative: str | Path,
+    dpath_downloaded_relative: StrOrPathLike,
+    dpath_organized_relative: StrOrPathLike,
+    dpath_bidsified_relative: StrOrPathLike,
     empty: bool,
     str_paths: bool,
     tmp_path: Path,

--- a/nipoppy_cli/tests/test_utils.py
+++ b/nipoppy_cli/tests/test_utils.py
@@ -3,6 +3,7 @@
 import json
 import re
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 import pytest
@@ -194,7 +195,7 @@ def test_add_path_timestamp(timestamp_format, expected, datetime_fixture):  # no
 )
 def test_save_df_with_backup(
     fname: str,
-    dname_backups: str | None,
+    dname_backups: Optional[str],
     dname_backups_processed: str,
     tmp_path: Path,
 ):

--- a/nipoppy_cli/tests/test_workflow_pipeline.py
+++ b/nipoppy_cli/tests/test_workflow_pipeline.py
@@ -25,7 +25,7 @@ class PipelineWorkflow(BasePipelineWorkflow):
         pipeline_version: str,
         participant: str = None,
         session: str = None,
-        fpath_layout: Optional[Path] = None,
+        fpath_layout: Optional[StrOrPathLike] = None,
         logger: Optional[logging.Logger] = None,
         dry_run: bool = False,
     ):

--- a/nipoppy_cli/tests/test_workflow_pipeline.py
+++ b/nipoppy_cli/tests/test_workflow_pipeline.py
@@ -10,7 +10,7 @@ from fids import fids
 
 from nipoppy.config.boutiques import BoutiquesConfig
 from nipoppy.config.main import PipelineConfig
-from nipoppy.utils import strip_session
+from nipoppy.utils import StrOrPathLike, strip_session
 from nipoppy.workflows.pipeline import BasePipelineWorkflow
 
 from .conftest import datetime_fixture  # noqa F401
@@ -20,7 +20,7 @@ from .conftest import create_empty_dataset, get_config, prepare_dataset
 class PipelineWorkflow(BasePipelineWorkflow):
     def __init__(
         self,
-        dpath_root: Path | str,
+        dpath_root: StrOrPathLike,
         pipeline_name: str,
         pipeline_version: str,
         participant: str = None,
@@ -105,7 +105,7 @@ def workflow(tmp_path: Path):
     )
 
 
-def _make_dummy_json(fpath: str | Path):
+def _make_dummy_json(fpath: StrOrPathLike):
     fpath = Path(fpath)
     fpath.parent.mkdir(parents=True, exist_ok=True)
     fpath.write_text("{}\n")


### PR DESCRIPTION
Closes #236

- Update CI workflow for tests
- Update `pyproject.toml` to 
- Add `from __future__ import annotations` to files that use `|` for `typing.Union` (only available in Python >= 3.10 otherwise)
- Use `from typing_extensions import Self` instead of `from typing import Self` (only available in Python >= 3.11) 
- Combine `str | pathlib.Path` into `StrOrPathLike` typevar